### PR TITLE
Add support for a custom logger

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ding-live/ding-go/internal/api"
-	"github.com/ding-live/ding-go/pkg/logging"
 	"github.com/ding-live/ding-go/pkg/status"
 	"github.com/google/uuid"
 	"github.com/nyaruka/phonenumbers"
@@ -44,21 +43,21 @@ type Config struct {
 	// If left unset, it'll be set to a default HTTP client for the package.
 	CustomHTTPClient *http.Client
 
-	// LeveledLogger is the logger that the backend will use to log errors,
+	// LeveledLogger is the logger that the will be used to log errors,
 	// warnings, and informational messages.
 	//
-	// LeveledLoggerInterface is implemented by LeveledLogger, and one can be
-	// initialized at the desired level of logging.  LeveledLoggerInterface
+	// LeveledLogger is implemented by Logger, and one can be
+	// initialized at the desired level of logging.  LeveledLogger
 	// also provides out-of-the-box compatibility with a Logrus Logger, but may
 	// require a thin shim for use with other logging libraries that use less
 	// standard conventions like Zap.
 	//
-	// Defaults to DefaultLeveledLogger.
+	// Defaults to ding.Logger.
 	//
-	// To set a logger that logs nothing, set this to a ding.LeveledLogger
-	// with a Level of LevelNull (simply setting this field to nil will not
+	// To set a logger that logs nothing, set this to a ding.Logger
+	// with a Level of ding.LevelNull (simply setting this field to nil will not
 	// work).
-	LeveledLogger logging.LeveledLogger
+	LeveledLogger LeveledLogger
 }
 
 var (
@@ -74,7 +73,7 @@ var (
 
 const apiBaseURL = "https://api.ding.live/v1"
 
-// NewClient returns a new Ding client
+// NewClient returns a new Ding client with a `Config` object.
 func NewClient(cfg Config) (*Client, error) {
 	if !isValidUUID(cfg.CustomerUUID) {
 		return nil, ErrInvalidCustomerUUID
@@ -83,7 +82,7 @@ func NewClient(cfg Config) (*Client, error) {
 	logger := cfg.LeveledLogger
 
 	if logger == nil {
-		logger = &logging.DefaultLeveledLogger
+		logger = &DefaultLeveledLogger
 	}
 
 	return &Client{

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package ding
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -85,15 +86,20 @@ func NewClient(cfg Config) (*Client, error) {
 		logger = &DefaultLeveledLogger
 	}
 
+	api, err := api.New(api.Config{
+		BaseURL:           apiBaseURL,
+		APIKey:            cfg.APIKey,
+		MaxNetworkRetries: cfg.MaxNetworkRetries,
+		CustomHTTPClient:  cfg.CustomHTTPClient,
+		LeveledLogger:     logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create API client: %w", err)
+	}
+
 	return &Client{
 		customerUUID: cfg.CustomerUUID,
-		api: *api.New(api.Config{
-			BaseURL:           apiBaseURL,
-			APIKey:            cfg.APIKey,
-			MaxNetworkRetries: cfg.MaxNetworkRetries,
-			CustomHTTPClient:  cfg.CustomHTTPClient,
-			LeveledLogger:     logger,
-		}),
+		api:          *api,
 	}, nil
 }
 

--- a/client.go
+++ b/client.go
@@ -47,7 +47,7 @@ type Config struct {
 	// warnings, and informational messages.
 	//
 	// LeveledLogger is implemented by Logger, and one can be
-	// initialized at the desired level of logging.  LeveledLogger
+	// initialized at the desired level of logging. LeveledLogger
 	// also provides out-of-the-box compatibility with a Logrus Logger, but may
 	// require a thin shim for use with other logging libraries that use less
 	// standard conventions like Zap.

--- a/examples/customlogger/customlogger.go
+++ b/examples/customlogger/customlogger.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	ding "github.com/ding-live/ding-go"
+)
+
+type Logger struct{}
+
+func (l *Logger) Debugf(msg string, keysAndValues ...interface{}) {
+	log.Printf("DEBUG: %s %v\n", msg, keysAndValues)
+}
+
+func (l *Logger) Errorf(msg string, keysAndValues ...interface{}) {
+	log.Printf("ERROR: %s\n", msg)
+}
+
+func (l *Logger) Infof(msg string, keysAndValues ...interface{}) {
+	log.Printf("INFO: %s\n", msg)
+}
+
+func (l *Logger) Warnf(msg string, keysAndValues ...interface{}) {
+	log.Printf("WARN: %s\n", msg)
+}
+
+func main() {
+	client, err := ding.NewClient(ding.Config{
+		CustomerUUID:      os.Getenv("DING_CUSTOMER_UUID"),
+		APIKey:            os.Getenv("DING_API_KEY"),
+		MaxNetworkRetries: ding.Int(4),
+		LeveledLogger:     &Logger{},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	auth, err := client.Authenticate(ding.AuthenticateOptions{
+		PhoneNumber: "+33xxxxxxxx",
+		IP:          ding.String("192.168.0.1"),
+		DeviceType:  &ding.DeviceTypeIOS,
+		AppVersion:  ding.String("1.2.0"),
+		CallbackURL: ding.String("https://example.com/callback"),
+	})
+	if err != nil {
+		log.Fatalf("unable to authenticate: %s", err)
+	}
+
+	log.Printf("auth: %+v", auth)
+}

--- a/examples/retry/retry.go
+++ b/examples/retry/retry.go
@@ -12,6 +12,10 @@ func main() {
 		CustomerUUID:      os.Getenv("DING_CUSTOMER_UUID"),
 		APIKey:            os.Getenv("DING_API_KEY"),
 		MaxNetworkRetries: ding.Int(4),
+		LeveledLogger: &ding.Logger{
+			// Disable default logging
+			Level: ding.LevelNull,
+		},
 	})
 	if err != nil {
 		panic(err)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ding-live/ding-go/pkg/logging"
 	"github.com/ding-live/ding-go/pkg/status"
 	"github.com/hashicorp/go-retryablehttp"
 )
@@ -17,7 +16,7 @@ type API struct {
 	baseURL       string
 	apiKey        string
 	hc            *http.Client
-	leveledLogger logging.LeveledLogger
+	leveledLogger LeveledLogger
 }
 
 type Config struct {
@@ -25,7 +24,7 @@ type Config struct {
 	APIKey            string
 	MaxNetworkRetries *int
 	CustomHTTPClient  *http.Client
-	LeveledLogger     logging.LeveledLogger
+	LeveledLogger     LeveledLogger
 }
 
 func New(cfg Config) *API {
@@ -278,8 +277,18 @@ func (a *API) post(ctx context.Context, url string, payload interface{}) (*http.
 
 // ----------------------------------------------------------------------------
 
+// LeveledLogger is an interface that can be implemented by any logger or a
+// logger wrapper to provide leveled logging. The methods accept a message
+// string and a variadic number of key-value pairs.
+type LeveledLogger interface {
+	Debugf(format string, v ...interface{})
+	Errorf(format string, v ...interface{})
+	Infof(format string, v ...interface{})
+	Warnf(format string, v ...interface{})
+}
+
 type loggerShim struct {
-	baseLogger logging.LeveledLogger
+	baseLogger LeveledLogger
 }
 
 func (l loggerShim) Error(msg string, keysAndValues ...interface{}) {
@@ -298,6 +307,6 @@ func (l loggerShim) Warn(msg string, keysAndValues ...interface{}) {
 	l.baseLogger.Warnf(fmt.Sprint(msg, keysAndValues))
 }
 
-func convertLogger(logger logging.LeveledLogger) retryablehttp.LeveledLogger {
+func convertLogger(logger LeveledLogger) retryablehttp.LeveledLogger {
 	return loggerShim{logger}
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -27,7 +27,7 @@ type Config struct {
 	LeveledLogger     LeveledLogger
 }
 
-func New(cfg Config) *API {
+func New(cfg Config) (*API, error) {
 	client := retryablehttp.NewClient()
 
 	if cfg.MaxNetworkRetries != nil {
@@ -42,12 +42,18 @@ func New(cfg Config) *API {
 		client.Logger = convertLogger(cfg.LeveledLogger)
 	}
 
-	return &API{
+	a := &API{
 		baseURL:       cfg.BaseURL,
 		apiKey:        cfg.APIKey,
 		hc:            client.StandardClient(),
 		leveledLogger: cfg.LeveledLogger,
 	}
+
+	if a.leveledLogger == nil {
+		return nil, fmt.Errorf("missing logger")
+	}
+
+	return a, nil
 }
 
 const APIKeyHeader = "x-api-key"

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -138,19 +138,20 @@ type AuthenticationResponse struct {
 func (a *API) Authentication(ctx context.Context, req AuthRequest) (*AuthenticationResponse, error) {
 	res, err := a.post(ctx, "authentication", req)
 	if err != nil {
-
 		return nil, ErrInternal
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
+		a.leveledLogger.Errorf("received a non-200 HTTP status %d", res.StatusCode)
+
 		if res.StatusCode == http.StatusForbidden {
 			return nil, ErrUnauthorized
 		}
 
 		var resp ErrorResponse
 		if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
-			a.leveledLogger.Errorf("decode response for non-200 HTTP status: %s", err)
+			a.leveledLogger.Errorf("unable to decode response: %s", err)
 			return nil, ErrInternal
 		}
 
@@ -161,7 +162,7 @@ func (a *API) Authentication(ctx context.Context, req AuthRequest) (*Authenticat
 
 	var resp AuthSuccessResponse
 	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
-		a.leveledLogger.Errorf("decode response for HTTP 200 status: %s", err)
+		a.leveledLogger.Errorf("unable to decode response of HTTP OK status: %s", err)
 		return nil, ErrInternal
 	}
 
@@ -184,13 +185,15 @@ func (a *API) Check(ctx context.Context, req CheckRequest) (*CheckResponse, erro
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
+		a.leveledLogger.Errorf("received a non-200 HTTP status %d", res.StatusCode)
+
 		if res.StatusCode == http.StatusForbidden {
 			return nil, ErrUnauthorized
 		}
 
 		var resp ErrorResponse
 		if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
-			a.leveledLogger.Errorf("decode response for non-200 HTTP status: %s", err)
+			a.leveledLogger.Errorf("unable to decode response: %s", err)
 			return nil, ErrInternal
 		}
 
@@ -201,7 +204,7 @@ func (a *API) Check(ctx context.Context, req CheckRequest) (*CheckResponse, erro
 
 	var resp CheckSuccessResponse
 	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
-		a.leveledLogger.Errorf("decode response for HTTP 200 status: %s", err)
+		a.leveledLogger.Errorf("unable to decode response of HTTP OK status: %s", err)
 		return nil, ErrInternal
 	}
 
@@ -223,13 +226,15 @@ func (a *API) Retry(ctx context.Context, req RetryRequest) (*RetryResponse, erro
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
+		a.leveledLogger.Errorf("received a non-200 HTTP status %d", res.StatusCode)
+
 		if res.StatusCode == http.StatusForbidden {
 			return nil, ErrUnauthorized
 		}
 
 		var resp ErrorResponse
 		if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
-			a.leveledLogger.Errorf("decode response for non-200 HTTP status: %s", err)
+			a.leveledLogger.Errorf("unable to decode response: %s", err)
 			return nil, ErrInternal
 		}
 
@@ -240,7 +245,7 @@ func (a *API) Retry(ctx context.Context, req RetryRequest) (*RetryResponse, erro
 
 	var resp RetrySuccessResponse
 	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
-		a.leveledLogger.Errorf("decode response for HTTP 200 status: %s", err)
+		a.leveledLogger.Errorf("unable to decode response of HTTP OK status: %s", err)
 		return nil, ErrInternal
 	}
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -18,14 +18,16 @@ const timeFmt = "2006-01-02T15:04:05.999999999Z"
 func TestInvalidAPIKey(t *testing.T) {
 	ts := testServer("")
 
-	a := New(Config{
+	a, err := New(Config{
 		BaseURL:          ts.URL,
 		APIKey:           testInvalidApiKey,
 		CustomHTTPClient: ts.Client(),
+		LeveledLogger:    testLogger{},
 	})
+	require.NoError(t, err)
 
-	_, err := a.Authentication(context.Background(), AuthRequest{})
-	assert.ErrorIs(t, err, ErrUnauthorized)
+	_, authErr := a.Authentication(context.Background(), AuthRequest{})
+	assert.ErrorIs(t, authErr, ErrUnauthorized)
 }
 
 func TestParseAuthSuccess(t *testing.T) {
@@ -42,11 +44,13 @@ func TestParseAuthSuccess(t *testing.T) {
 
 	ts := testServer(rawRes)
 
-	a := New(Config{
+	a, err := New(Config{
 		BaseURL:          ts.URL,
 		APIKey:           testApiKey,
 		CustomHTTPClient: ts.Client(),
+		LeveledLogger:    testLogger{},
 	})
+	require.NoError(t, err)
 
 	res, err := a.Authentication(context.Background(), AuthRequest{})
 	require.NoError(t, err)
@@ -70,11 +74,13 @@ func TestParseError(t *testing.T) {
 
 	ts := testServer(rawRes, http.StatusBadRequest)
 
-	a := New(Config{
+	a, err := New(Config{
 		BaseURL:          ts.URL,
 		APIKey:           testApiKey,
 		CustomHTTPClient: ts.Client(),
+		LeveledLogger:    testLogger{},
 	})
+	require.NoError(t, err)
 
 	res, err := a.Authentication(context.Background(), AuthRequest{})
 	require.NoError(t, err)
@@ -98,11 +104,13 @@ func TestParseCheckSuccess(t *testing.T) {
 
 	ts := testServer(rawRes)
 
-	a := New(Config{
+	a, err := New(Config{
 		BaseURL:          ts.URL,
 		APIKey:           testApiKey,
 		CustomHTTPClient: ts.Client(),
+		LeveledLogger:    testLogger{},
 	})
+	require.NoError(t, err)
 
 	res, err := a.Check(context.Background(), CheckRequest{})
 	require.NoError(t, err)
@@ -130,11 +138,13 @@ func TestParseRetrySuccess(t *testing.T) {
 
 	ts := testServer(rawRes)
 
-	a := New(Config{
+	a, err := New(Config{
 		BaseURL:          ts.URL,
 		APIKey:           testApiKey,
 		CustomHTTPClient: ts.Client(),
+		LeveledLogger:    testLogger{},
 	})
+	require.NoError(t, err)
 
 	res, err := a.Retry(context.Background(), RetryRequest{})
 	require.NoError(t, err)
@@ -155,14 +165,16 @@ func TestParseInvalidResponse(t *testing.T) {
 
 	ts := testServer(rawRes)
 
-	a := New(Config{
+	a, err := New(Config{
 		BaseURL:          ts.URL,
 		APIKey:           testApiKey,
 		CustomHTTPClient: ts.Client(),
+		LeveledLogger:    testLogger{},
 	})
+	require.NoError(t, err)
 
-	_, err := a.Authentication(context.Background(), AuthRequest{})
-	require.ErrorIs(t, err, ErrInternal)
+	_, authErr := a.Authentication(context.Background(), AuthRequest{})
+	require.ErrorIs(t, authErr, ErrInternal)
 }
 
 func TestUnknownAuthStatus(t *testing.T) {
@@ -179,11 +191,13 @@ func TestUnknownAuthStatus(t *testing.T) {
 
 	ts := testServer(rawRes)
 
-	a := New(Config{
+	a, err := New(Config{
 		BaseURL:          ts.URL,
 		APIKey:           testApiKey,
 		CustomHTTPClient: ts.Client(),
+		LeveledLogger:    testLogger{},
 	})
+	require.NoError(t, err)
 
 	res, err := a.Authentication(context.Background(), AuthRequest{})
 	require.NoError(t, err)
@@ -197,3 +211,12 @@ func TestUnknownAuthStatus(t *testing.T) {
 		},
 	}, res)
 }
+
+// ----------------------------------------------------------------------------
+
+type testLogger struct{}
+
+func (testLogger) Debugf(string, ...interface{}) {}
+func (testLogger) Infof(string, ...interface{})  {}
+func (testLogger) Warnf(string, ...interface{})  {}
+func (testLogger) Errorf(string, ...interface{}) {}

--- a/log.go
+++ b/log.go
@@ -1,4 +1,4 @@
-package logging
+package ding
 
 import (
 	"fmt"

--- a/log.go
+++ b/log.go
@@ -29,7 +29,7 @@ const (
 // errors, warnings, and informational messages.
 //
 // LeveledLoggerInterface is implemented by LeveledLogger, and one can be
-// initialized at the desired level of logging.  LeveledLoggerInterface also
+// initialized at the desired level of logging. LeveledLoggerInterface also
 // provides out-of-the-box compatibility with a Logrus Logger, but may require
 // a thin shim for use with other logging libraries that use less standard
 // conventions like Zap.

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,0 +1,86 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+)
+
+// LeveledLogger is an interface that can be implemented by any logger or a
+// logger wrapper to provide leveled logging. The methods accept a message
+// string and a variadic number of key-value pairs.
+type LeveledLogger interface {
+	Debugf(format string, v ...interface{})
+	Errorf(format string, v ...interface{})
+	Infof(format string, v ...interface{})
+	Warnf(format string, v ...interface{})
+}
+
+type Level int
+
+const (
+	LevelDebug Level = iota
+	LevelInfo
+	LevelWarn
+	LevelError
+	LevelNull
+)
+
+// DefaultLeveledLogger is the default logger that the library will use to log
+// errors, warnings, and informational messages.
+//
+// LeveledLoggerInterface is implemented by LeveledLogger, and one can be
+// initialized at the desired level of logging.  LeveledLoggerInterface also
+// provides out-of-the-box compatibility with a Logrus Logger, but may require
+// a thin shim for use with other logging libraries that use less standard
+// conventions like Zap.
+//
+// This Logger will be inherited by any backends created by default, but will
+// be overridden if a backend is created with GetBackendWithConfig with a
+// custom LeveledLogger set.
+var DefaultLeveledLogger Logger = Logger{
+	Level: LevelError,
+}
+
+// Logger is a leveled logger implementation.
+//
+// It prints warnings and errors to `os.Stderr` and other messages to
+// `os.Stdout`.
+type Logger struct {
+	// Level is the minimum logging level that will be emitted by this logger.
+	//
+	// For example, a Level set to LevelWarn will emit warnings and errors, but
+	// not informational or debug messages.
+	//
+	// Always set this with a constant like LevelWarn because the individual
+	// values are not guaranteed to be stable.
+	Level Level
+}
+
+// Debugf logs a debug message using Printf conventions.
+func (l *Logger) Debugf(format string, v ...interface{}) {
+	if l.Level >= LevelDebug {
+		fmt.Fprintf(os.Stdout, "[DEBUG] "+format+"\n", v...)
+	}
+}
+
+// Errorf logs a warning message using Printf conventions.
+func (l *Logger) Errorf(format string, v ...interface{}) {
+	// Infof logs a debug message using Printf conventions.
+	if l.Level >= LevelError {
+		fmt.Fprintf(os.Stderr, "[ERROR] "+format+"\n", v...)
+	}
+}
+
+// Infof logs an informational message using Printf conventions.
+func (l *Logger) Infof(format string, v ...interface{}) {
+	if l.Level >= LevelInfo {
+		fmt.Fprintf(os.Stdout, "[INFO] "+format+"\n", v...)
+	}
+}
+
+// Warnf logs a warning message using Printf conventions.
+func (l *Logger) Warnf(format string, v ...interface{}) {
+	if l.Level >= LevelWarn {
+		fmt.Fprintf(os.Stderr, "[WARN] "+format+"\n", v...)
+	}
+}


### PR DESCRIPTION
Allows users to add a custom `LeveledLogger` implementation to the client so that they can connect their own observability stack to the Ding SDK.